### PR TITLE
Add Symbolic Profile Styles API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ can be analysed later.  Most of the code and comments are in Spanish.
 
 ```
 ecosistema_ia/
-├── api/              # (placeholders for FastAPI endpoints)
+├── api/              # FastAPI server exposing the SPS REST API
 ├── agentes/          # agent implementations
 ├── datasets/         # CSV data used by the territory
 ├── datos/            # output logs generated during execution
@@ -62,8 +62,25 @@ A `Territorio` component maintains an immutable CSV log and adjusts parameters l
 Agents evolve by rewards and natural selection, and visualisations progress from ASCII to interactive dashboards.
 
 
+## Symbolic Profile Styles API
+
+The module `ecosistema_ia.sps` translates symbolic profile tokens to design
+variables such as colours and fonts.  A small FastAPI server under
+`ecosistema_ia/api` exposes an endpoint that receives a profile token and
+returns the generated styles:
+
+```bash
+uvicorn ecosistema_ia.api.servidor:app --reload
+```
+
+Send a POST request to `/sps/styles` with a JSON body containing
+`cromotipo`, `ritmo_cognitivo`, `arquetipo_narrativo` and `estilo_perceptual`.
+
+The API responds with a dictionary of design variables that front-end
+frameworks can consume.
+
 ## Notes
 
-Many modules under `api/` and `visualizacion/` are placeholders for future
+Many modules under `visualizacion/` are still placeholders for future
 expansion. The current focus is the command line simulation found in
-`main.py`.
+`main.py` and the new SPS API.

--- a/ecosistema_ia/api/endpoints.py
+++ b/ecosistema_ia/api/endpoints.py
@@ -1,0 +1,22 @@
+"""FastAPI endpoints for the SPS library."""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+from ecosistema_ia.sps import SymbolicProfile, generate_styles
+
+router = APIRouter()
+
+
+class ProfileToken(BaseModel):
+    cromotipo: str
+    ritmo_cognitivo: str
+    arquetipo_narrativo: str
+    estilo_perceptual: str
+
+
+@router.post("/sps/styles")
+def get_styles(token: ProfileToken):
+    """Return design variables for a symbolic profile token."""
+    profile = SymbolicProfile(**token.dict())
+    styles = generate_styles(profile.to_token())
+    return {"styles": styles}

--- a/ecosistema_ia/api/servidor.py
+++ b/ecosistema_ia/api/servidor.py
@@ -1,0 +1,17 @@
+"""Small FastAPI server exposing SPS endpoints."""
+
+from fastapi import FastAPI
+from .endpoints import router as sps_router
+
+app = FastAPI(title="Mimir SPS API")
+app.include_router(sps_router)
+
+
+@app.get("/")
+def root():
+    return {"message": "SPS API running"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ecosistema_ia/sps/__init__.py
+++ b/ecosistema_ia/sps/__init__.py
@@ -1,0 +1,6 @@
+"""Symbolic Profile Styles (SPS) library."""
+
+from .models import SymbolicProfile
+from .mappings import generate_styles
+
+__all__ = ["SymbolicProfile", "generate_styles"]

--- a/ecosistema_ia/sps/mappings.py
+++ b/ecosistema_ia/sps/mappings.py
@@ -1,0 +1,37 @@
+"""Simple mapping from symbolic profile dimensions to design variables."""
+
+from typing import Dict
+
+# Example mapping dictionaries; in real use these could be loaded from a database
+CROMOTIPO_COLOR = {
+    "sol": "#FFD700",
+    "luna": "#B0C4DE",
+    "tierra": "#8FBC8F",
+}
+
+RITMO_TIPOGRAFIA = {
+    "lento": "serif",
+    "medio": "sans-serif",
+    "rapido": "monospace",
+}
+
+ARQUETIPO_ICONO = {
+    "explorador": "compass",
+    "cuidador": "heart",
+    "forajido": "skull",
+}
+
+ESTILO_ANIMACION = {
+    "visual": "fade",
+    "auditivo": "pulse",
+    "kinestesico": "bounce",
+}
+
+def generate_styles(token: Dict[str, str]) -> Dict[str, str]:
+    """Return design variables derived from a symbolic profile token."""
+    return {
+        "color_primario": CROMOTIPO_COLOR.get(token.get("cromotipo"), "#FFFFFF"),
+        "fuente_base": RITMO_TIPOGRAFIA.get(token.get("ritmo_cognitivo"), "sans-serif"),
+        "icono": ARQUETIPO_ICONO.get(token.get("arquetipo_narrativo"), "star"),
+        "animacion": ESTILO_ANIMACION.get(token.get("estilo_perceptual"), "fade"),
+    }

--- a/ecosistema_ia/sps/models.py
+++ b/ecosistema_ia/sps/models.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class SymbolicProfile:
+    """Basic symbolic profile token."""
+    cromotipo: str
+    ritmo_cognitivo: str
+    arquetipo_narrativo: str
+    estilo_perceptual: str
+
+    def to_token(self) -> Dict[str, str]:
+        return {
+            "cromotipo": self.cromotipo,
+            "ritmo_cognitivo": self.ritmo_cognitivo,
+            "arquetipo_narrativo": self.arquetipo_narrativo,
+            "estilo_perceptual": self.estilo_perceptual,
+        }


### PR DESCRIPTION
## Summary
- add Symbolic Profile Styles (SPS) library
- expose `/sps/styles` REST endpoint with FastAPI
- document how to run the SPS API in README

## Testing
- `python -m py_compile ecosistema_ia/sps/*.py ecosistema_ia/api/*.py`
- `python -m ecosistema_ia.api.servidor` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_684056433c388322896c2db487738c7e