### PR TITLE
Improve Metatron observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ python -m ecosistema_ia.main
 
 Logs and CSV files will be written inside the `ecosistema_ia/datos` folder.
 
+`Metatron` ahora también produce archivos `metatron_heatmap.csv` y
+`metatron_semantics.csv`.  El primero resume la densidad de agentes por
+coordenada, permitiendo generar mapas de calor con la función
+`visualizacion.graficos.generar_heatmap`.  El segundo almacena tokens
+relevantes para analizar la evolución semántica del ecosistema.
+
 ### Extracting agent code
 
 The helper script `ecosistema_ia/texto_agentes.py` concatenates the source
@@ -81,6 +87,6 @@ frameworks can consume.
 
 ## Notes
 
-Many modules under `visualizacion/` are still placeholders for future
-expansion. The current focus is the command line simulation found in
-`main.py` and the new SPS API.
+Most modules under `visualizacion/` remain lightweight, but now include a
+utility to generarate heatmaps from Metatron logs. The main focus continues to
+be the command line simulation found in `main.py` and the SPS API.

--- a/ecosistema_ia/agentes/tipos/sublimes/metatron.py
+++ b/ecosistema_ia/agentes/tipos/sublimes/metatron.py
@@ -2,23 +2,64 @@
 
 import csv
 import os
-from datetime import datetime
+from collections import Counter
 from ecosistema_ia.agentes.tipos.sublimes.sublime_base import SublimeBase
+from ecosistema_ia.config import (
+    CSV_METATRON_PATH,
+    CSV_METATRON_HEATMAP_PATH,
+    CSV_METATRON_SEMANTICS_PATH,
+)
 
 class Metatron(SublimeBase):
-    def __init__(self, identificador="MET-001", x=0, y=0, z=0):
+    def __init__(
+        self,
+        identificador: str = "MET-001",
+        x: int = 0,
+        y: int = 0,
+        z: int = 0,
+        ruta_csv: str = CSV_METATRON_PATH,
+        ruta_heatmap: str = CSV_METATRON_HEATMAP_PATH,
+        ruta_semantica: str = CSV_METATRON_SEMANTICS_PATH,
+    ) -> None:
         super().__init__(identificador, x, y, z, funcion="metatron")
         self.reporte = []
-        self.ruta_csv = "datos/metatron.csv"
+        self.ruta_csv = str(ruta_csv)
+        self.ruta_heatmap = str(ruta_heatmap)
+        self.ruta_semantica = str(ruta_semantica)
 
-        os.makedirs(os.path.dirname(self.ruta_csv), exist_ok=True)
+        for ruta in [self.ruta_csv, self.ruta_heatmap, self.ruta_semantica]:
+            os.makedirs(os.path.dirname(ruta), exist_ok=True)
 
-        with open(self.ruta_csv, mode='w', newline='') as f:
-            writer = csv.writer(f)
-            writer.writerow(["ciclo", "agente", "funcion", "edad", "x", "y", "z", "recompensa_total", "calificacion"])
+        if not os.path.exists(self.ruta_csv):
+            with open(self.ruta_csv, mode="w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "ciclo",
+                    "agente",
+                    "funcion",
+                    "edad",
+                    "x",
+                    "y",
+                    "z",
+                    "recompensa_total",
+                    "calificacion",
+                ])
+
+        if not os.path.exists(self.ruta_heatmap):
+            with open(self.ruta_heatmap, mode="w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["ciclo", "x", "y", "z", "conteo"])
+
+        if not os.path.exists(self.ruta_semantica):
+            with open(self.ruta_semantica, mode="w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["ciclo", "token", "conteo"])
 
     def observar(self, territorio, agentes, ciclo):
-        with open(self.ruta_csv, mode='a', newline='') as f:
+        posicion_contador = Counter()
+        semantico = Counter()
+
+        with open(self.ruta_csv, mode="a", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             for agente in agentes:
                 writer.writerow([
@@ -30,8 +71,30 @@ class Metatron(SublimeBase):
                     getattr(agente, "y", -1),
                     getattr(agente, "z", -1),
                     getattr(agente, "recompensa_total", 0),
-                    getattr(agente, "calificacion", "N/A")
+                    getattr(agente, "calificacion", "N/A"),
                 ])
+                posicion_contador[(agente.x, agente.y, agente.z)] += 1
+                for m in getattr(agente, "memoria", []):
+                    texto = f"{m.get('entrada','')} {m.get('resultado','')}"
+                    tokens = texto.lower().split()
+                    semantico.update(tokens)
+
+        with open(self.ruta_heatmap, mode="a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            for (x, y, z), conteo in posicion_contador.items():
+                writer.writerow([ciclo, x, y, z, conteo])
+
+        with open(self.ruta_semantica, mode="a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            for token, conteo in semantico.most_common(10):
+                writer.writerow([ciclo, token, conteo])
+
+        try:
+            from ecosistema_ia.visualizacion.graficos import generar_heatmap
+            generar_heatmap(self.ruta_heatmap, ciclo)
+        except Exception as e:
+            print(f"⚠️ Error generando heatmap: {e}")
+
         print(f"👁️ {self.identificador} registró {len(agentes)} agentes en el ciclo {ciclo}")
 
 __all__ = ["Metatron"]

--- a/ecosistema_ia/config.py
+++ b/ecosistema_ia/config.py
@@ -24,6 +24,8 @@ LOGS_DIR = DATA_DIR / "logs"
 # Rutas de archivos especiales
 CSV_TERRITORIO_PATH = DATA_DIR / "territorio.csv"
 CSV_METATRON_PATH = DATA_DIR / "metatron.csv"
+CSV_METATRON_HEATMAP_PATH = DATA_DIR / "metatron_heatmap.csv"
+CSV_METATRON_SEMANTICS_PATH = DATA_DIR / "metatron_semantics.csv"
 
 # Bandera para controlar visualización en consola
 MOSTRAR_INFO_CONSOLA = True

--- a/ecosistema_ia/visualizacion/graficos.py
+++ b/ecosistema_ia/visualizacion/graficos.py
@@ -1,0 +1,57 @@
+"""Funciones de visualización para el ecosistema Mimir."""
+
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def generar_heatmap(ruta_csv: str, ciclo: int | None = None, output_dir: str | None = None) -> Path:
+    """Genera una imagen de heatmap a partir de las posiciones registradas.
+
+    Parameters
+    ----------
+    ruta_csv: str
+        Ruta del CSV con columnas [ciclo, x, y, z, conteo].
+    ciclo: int | None
+        Si se indica, filtra los datos para ese ciclo específico.
+    output_dir: str | None
+        Carpeta donde guardar la imagen generada. Por defecto junto al CSV.
+
+    Returns
+    -------
+    Path
+        Ruta del archivo PNG creado.
+    """
+
+    csv_path = Path(ruta_csv)
+    df = pd.read_csv(csv_path)
+    if ciclo is not None:
+        df = df[df["ciclo"] == ciclo]
+    if df.empty:
+        raise ValueError("No hay datos para generar el heatmap")
+
+    max_x = int(df["x"].max()) + 1
+    max_y = int(df["y"].max()) + 1
+    matriz = np.zeros((max_x, max_y))
+    for _, fila in df.iterrows():
+        matriz[int(fila["x"]), int(fila["y"])] += fila["conteo"]
+
+    plt.figure(figsize=(6, 5))
+    plt.imshow(matriz, cmap="hot", origin="lower")
+    plt.colorbar(label="Agentes")
+    plt.xlabel("Y")
+    plt.ylabel("X")
+
+    out_dir = Path(output_dir) if output_dir else csv_path.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    nombre = f"heatmap_{ciclo if ciclo is not None else 'total'}.png"
+    destino = out_dir / nombre
+    plt.tight_layout()
+    plt.savefig(destino)
+    plt.close()
+    return destino
+
+
+__all__ = ["generar_heatmap"]
+


### PR DESCRIPTION
## Summary
- extend `config.py` with new Metatron CSV paths
- enhance `Metatron` to log heatmap and semantic data and generate heatmaps
- implement `visualizacion.graficos.generar_heatmap`
- document new logging features in the README

## Testing
- `python -m compileall ecosistema_ia`

------
https://chatgpt.com/codex/tasks/task_b_6840ab8aa5008322b5bd8282b146139a