### PR TITLE
Add Plotly dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ conda activate mimir
 ```
 
 The project only relies on standard libraries plus `pandas`, `numpy`,
-`matplotlib`, `scikit-learn`, `fastapi` and `uvicorn`.
+`matplotlib`, `scikit-learn`, `fastapi`, `uvicorn` and `plotly`.
 
 ## Running
 

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - scikit-learn
   - fastapi
   - uvicorn
+  - plotly


### PR DESCRIPTION
## Summary
- add `plotly` to the Conda environment file
- document `plotly` in the requirements section of the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840c9f058bc832285775eb77d2e973d