### PR TITLE
Implement dashboard and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ coordenada, permitiendo generar mapas de calor con la función
 `visualizacion.graficos.generar_heatmap`.  El segundo almacena tokens
 relevantes para analizar la evolución semántica del ecosistema.
 
+### Dashboard
+
+Un tablero interactivo permite explorar visualmente la densidad de agentes y los tokens semánticos más frecuentes.  Tras generar los CSVs correspondientes, ejecútalo con:
+
+```bash
+python -m ecosistema_ia.visualizacion.dashboard
+```
+
 ### Extracting agent code
 
 The helper script `ecosistema_ia/texto_agentes.py` concatenates the source

--- a/ecosistema_ia/visualizacion/dashboard.py
+++ b/ecosistema_ia/visualizacion/dashboard.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pandas as pd
+import plotly.graph_objects as go
+from dash import Dash, dcc, html
+
+from ecosistema_ia.config import CSV_METATRON_HEATMAP_PATH, CSV_METATRON_SEMANTICS_PATH
+
+
+def cargar_heatmap_dataframe(path: Path) -> pd.DataFrame:
+    """Read the heatmap csv and return pivoted dataframe by x and y."""
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        return pd.DataFrame()
+    if df.empty:
+        return pd.DataFrame()
+    pivot = (
+        df.groupby(["x", "y"])["conteo"].sum().unstack(fill_value=0).sort_index()
+    )
+    return pivot
+
+
+def cargar_semantica_dataframe(path: Path, top: int = 10) -> pd.DataFrame:
+    """Return dataframe with top tokens and counts."""
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        return pd.DataFrame(columns=["token", "conteo"])
+    if df.empty:
+        return pd.DataFrame(columns=["token", "conteo"])
+    agg = df.groupby("token")["conteo"].sum().sort_values(ascending=False).head(top)
+    return agg.reset_index()
+
+
+def crear_app() -> Dash:
+    """Create the Dash application."""
+    app = Dash(__name__)
+
+    heatmap_df = cargar_heatmap_dataframe(CSV_METATRON_HEATMAP_PATH)
+    sem_df = cargar_semantica_dataframe(CSV_METATRON_SEMANTICS_PATH)
+
+    heatmap_fig = go.Figure()
+    if not heatmap_df.empty:
+        heatmap_fig.add_trace(
+            go.Heatmap(
+                z=heatmap_df.values,
+                x=heatmap_df.columns.astype(str),
+                y=heatmap_df.index.astype(str),
+                colorscale="Hot",
+            )
+        )
+        heatmap_fig.update_layout(title="Densidad de Agentes", xaxis_title="y", yaxis_title="x")
+
+    bar_fig = go.Figure()
+    if not sem_df.empty:
+        bar_fig.add_trace(go.Bar(x=sem_df["token"], y=sem_df["conteo"]))
+        bar_fig.update_layout(title="Tokens Semánticos Principales", xaxis_title="token", yaxis_title="conteo")
+
+    app.layout = html.Div(
+        [
+            html.H1("Mimir Dashboard"),
+            dcc.Graph(figure=heatmap_fig),
+            dcc.Graph(figure=bar_fig),
+        ]
+    )
+    return app
+
+
+if __name__ == "__main__":
+    app = crear_app()
+    app.run(debug=True)

--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - fastapi
   - uvicorn
   - plotly
+  - dash


### PR DESCRIPTION
## Summary
- implement interactive Dash dashboard displaying agent heatmap and top semantic tokens
- add `dash` to dependencies
- document new dashboard usage in README

## Testing
- `timeout 5 python -m ecosistema_ia.visualizacion.dashboard`


------
https://chatgpt.com/codex/tasks/task_b_6842f827f8d08322a015e008e40fc627