### PR TITLE
Enable parallel agent execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ After installing the dependencies, run the ecosystem with:
 python -m ecosistema_ia.main
 ```
 
+Add the `--paralelo` flag to execute each agent in a separate process:
+
+```
+python -m ecosistema_ia.main --paralelo
+```
+
 Logs and CSV files will be written inside the `ecosistema_ia/datos` folder.
 
 `Metatron` ahora también produce archivos `metatron_heatmap.csv` y

--- a/ecosistema_ia/entorno/paralelo.py
+++ b/ecosistema_ia/entorno/paralelo.py
@@ -1,0 +1,34 @@
+from concurrent.futures import ProcessPoolExecutor
+from typing import List
+
+
+def _actuar_agente(agente, territorio, agentes):
+    """Ejecuta la acción de un agente en un proceso independiente."""
+    try:
+        agente.actuar(territorio, otros_agentes=agentes)
+    except Exception as e:
+        print(f"⚠️ Error en {agente.identificador}: {e}")
+    return agente
+
+
+def run_parallel(agentes: List, territorio, max_workers: int | None = None) -> List:
+    """Lanza la fase de actuación de los agentes usando múltiples procesos.
+
+    :param agentes: lista de agentes a ejecutar.
+    :param territorio: instancia compartida del territorio.
+    :param max_workers: opcional, número máximo de procesos.
+    :return: lista de agentes actualizados tras actuar.
+    """
+    tareas = []
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        for agente in agentes:
+            tareas.append(executor.submit(_actuar_agente, agente, territorio, agentes))
+        resultados = []
+        for futuro in tareas:
+            try:
+                resultados.append(futuro.result())
+            except Exception as e:
+                print(f"⚠️ Error en ejecución paralela: {e}")
+    return resultados
+
+__all__ = ["run_parallel"]

--- a/ecosistema_ia/main.py
+++ b/ecosistema_ia/main.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ecosistema_ia.entorno.territorio import Territorio
+from ecosistema_ia.entorno.paralelo import run_parallel
 from ecosistema_ia.agentes.tipos.sublimes.metatron import Metatron
 from ecosistema_ia.agentes.tipos.sublimes.mensajero import Mensajero
 from ecosistema_ia.ml.optimizacion_territorio import estimar_ciclos_optimos
@@ -33,7 +34,7 @@ def cargar_agentes_dinamicamente() -> list:
                     print(f"❌ Error al cargar {ruta_import}: {e}")
     return agentes
 
-def main():
+def main(paralelo: bool = False):
     print("🌱 Iniciando el ecosistema Mimir...\n")
 
     # 1. Inicializar el Territorio
@@ -63,8 +64,13 @@ def main():
 
             try:
                 nuevos_agentes = []
+                if paralelo:
+                    agentes = run_parallel(agentes, territorio)
+                else:
+                    for agente in agentes:
+                        agente.actuar(territorio, otros_agentes=agentes)
+
                 for agente in agentes:
-                    agente.actuar(territorio, otros_agentes=agentes)
                     if hasattr(agente, "puede_reproducirse") and agente.puede_reproducirse():
                         nuevo_id = f"{agente.identificador}-R{agente.edad}"
                         nuevo = agente.reproducirse(nuevo_id)
@@ -94,4 +100,10 @@ def main():
     print("\n✅ Ecosistema finalizado. Reporte de Metatrón generado.")
 
 if __name__ == '__main__':
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Simulación del ecosistema Mimir')
+    parser.add_argument('--paralelo', action='store_true', help='Ejecutar agentes en paralelo')
+    args = parser.parse_args()
+
+    main(paralelo=args.paralelo)


### PR DESCRIPTION
## Summary
- add `run_parallel` helper using `ProcessPoolExecutor`
- allow running cycles in parallel via `--paralelo` flag
- document the new command line option in README

## Testing
- `python -m py_compile ecosistema_ia/main.py ecosistema_ia/entorno/paralelo.py`
- `python -m ecosistema_ia.main --help` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_b_6842f939ab80832297a2b37b543c9502