### PR TITLE
Add pip requirements file and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ conda activate mimir
 The project only relies on standard libraries plus `pandas`, `numpy`,
 `matplotlib`, `scikit-learn`, `fastapi`, `uvicorn` and `plotly`.
 
+If you prefer a standard Python setup, the same dependencies are listed in
+`requirements.txt`. Install them with:
+
+```
+pip install -r requirements.txt
+```
+
 ## Running
 
 After installing the dependencies, run the ecosystem with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+matplotlib
+scikit-learn
+fastapi
+uvicorn
+plotly
+dash


### PR DESCRIPTION
## Summary
- generate `requirements.txt` from conda environment
- document pip-based install option in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684305b27f9883228f0cd0b4e8a71e0a