### PR TITLE
Expose dataset helpers via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ for row in previsualizar_csv("Episodes FAST.csv", n=3):
 
 These utilities report the dimensions of each dataset and return a small sample
 of rows for quick inspection.
+
+### Dataset API
+
+You can also query these helpers through the FastAPI server:
+
+```bash
+uvicorn ecosistema_ia.api.servidor:app --reload
+```
+
+* `GET /datasets` lists available CSV files.
+* `GET /datasets/preview?name=<file>&n=<rows>` shows the first ``n`` rows of a CSV (``n`` defaults to ``5``).
 ## White Paper Highlights
 
 The "Mimir White Paper" describes a decentralized ecosystem where CSV files act as a multidimensional territory. Agents inhabit these files, modify them under evolutionary rules and compete for survival.

--- a/ecosistema_ia/api/endpoints.py
+++ b/ecosistema_ia/api/endpoints.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 from ecosistema_ia.sps import SymbolicProfile, generate_styles
+from ecosistema_ia.entorno.exploracion import listar_csvs, previsualizar_csv
 
 router = APIRouter()
 
@@ -20,3 +21,16 @@ def get_styles(token: ProfileToken):
     profile = SymbolicProfile(**token.dict())
     styles = generate_styles(profile.to_token())
     return {"styles": styles}
+
+
+@router.get("/datasets")
+def get_datasets():
+    """Return a list of available CSV datasets."""
+    return {"datasets": listar_csvs()}
+
+
+@router.get("/datasets/preview")
+def preview_dataset(name: str, n: int = 5):
+    """Return the first ``n`` rows of the selected CSV file."""
+    rows = previsualizar_csv(name, n=n)
+    return {"preview": rows}

--- a/ecosistema_ia/api/servidor.py
+++ b/ecosistema_ia/api/servidor.py
@@ -1,10 +1,10 @@
-"""Small FastAPI server exposing SPS endpoints."""
+"""Small FastAPI server exposing SPS and dataset endpoints."""
 
 from fastapi import FastAPI
-from .endpoints import router as sps_router
+from .endpoints import router as api_router
 
 app = FastAPI(title="Mimir SPS API")
-app.include_router(sps_router)
+app.include_router(api_router)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- add dataset listing and preview endpoints
- mount new routes in the FastAPI server
- document dataset API usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843093984b48322aaadfe559d660be8