### PR TITLE
Add FastAPI dataset API tests

### DIFF
--- a/tests/test_api_datasets.py
+++ b/tests/test_api_datasets.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from ecosistema_ia.api.servidor import app
+
+client = TestClient(app)
+
+
+def test_get_datasets_not_empty():
+    response = client.get("/datasets")
+    assert response.status_code == 200
+    data = response.json()
+    assert "datasets" in data
+    datasets = data["datasets"]
+    assert isinstance(datasets, list)
+    assert len(datasets) > 0
+
+
+def test_preview_has_expected_rows():
+    # obtain one existing dataset name
+    datasets = client.get("/datasets").json()["datasets"]
+    name = datasets[0]["archivo"]
+    n = 3
+    response = client.get("/datasets/preview", params={"name": name, "n": n})
+    assert response.status_code == 200
+    data = response.json()
+    assert "preview" in data
+    preview = data["preview"]
+    assert isinstance(preview, list)
+    assert len(preview) == n + 1


### PR DESCRIPTION
## Summary
- create `tests/test_api_datasets.py` for dataset API endpoints
- ensure `GET /datasets` returns a non-empty list
- ensure dataset preview endpoint returns header + `n` rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430a3d38708322a9170b90fd0ee972