### PR TITLE
Sync pip requirements with conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ conda activate mimir
 The project only relies on standard libraries plus `pandas`, `numpy`,
 `matplotlib`, `scikit-learn`, `fastapi`, `uvicorn` and `plotly`.
 
-If you prefer a standard Python setup, the same dependencies are listed in
-`requirements.txt`. Install them with:
+If you prefer a standard Python setup, the same dependencies are listed with
+pinned versions in `requirements.txt`. This file mirrors the Conda
+environment so both installation methods remain in sync. Install them with:
 
 ```
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pandas
-numpy
-matplotlib
-scikit-learn
-fastapi
-uvicorn
-plotly
-dash
+pandas==2.3.0
+numpy==2.2.6
+matplotlib==3.10.3
+scikit-learn==1.7.0
+fastapi==0.115.12
+uvicorn==0.34.3
+plotly==6.1.2
+dash==3.0.4


### PR DESCRIPTION
## Summary
- pin package versions in `requirements.txt`
- remove redundant nested `requirements.txt`
- document pip install command now using pinned versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68430adb5f8483228036918e1809f155