### PR TITLE
Capture list returns from agents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ fastapi==0.115.12
 uvicorn==0.34.3
 plotly==6.1.2
 dash==3.0.4
+httpx==0.28.1

--- a/tests/test_main_cycle.py
+++ b/tests/test_main_cycle.py
@@ -1,0 +1,37 @@
+from ecosistema_ia.main import ejecutar_ciclo
+from ecosistema_ia.entorno.territorio import Territorio
+from ecosistema_ia.agentes.tipos.carnivoros.divisor_reproductor import DivisorReproductor
+from ecosistema_ia.agentes.tipos.carnivoros.destructor import Destructor
+from ecosistema_ia.agentes.tipos.herbivoros.herbivoro import Herbivoro
+
+
+def _herbivoro(id_):
+    h = Herbivoro(id_, 0, 0, 0)
+    h.memoria.append({"dato": "x"})
+    return h
+
+
+def test_ejecutar_ciclo_agrega_agentes():
+    territorio = Territorio()
+    dr = DivisorReproductor("DR-001", 0, 0, 0)
+    agentes = [dr] + [_herbivoro(f"H{i}") for i in range(4)]
+    cantidad_inicial = len(agentes)
+
+    agentes = ejecutar_ciclo(agentes, territorio)
+
+    assert len(agentes) == cantidad_inicial + 1
+
+
+def test_ejecutar_ciclo_elimina_agentes():
+    territorio = Territorio()
+    dest = Destructor("D-001", 0, 0, 0)
+    rojo = Herbivoro("HR-1", 0, 0, 0)
+    rojo.calificacion = "roja"
+    rojo.memoria = []
+    agentes = [dest, rojo]
+
+    agentes = ejecutar_ciclo(agentes, territorio)
+
+    ids = [a.identificador for a in agentes]
+    assert "HR-1" not in ids
+    assert "D-001" in ids


### PR DESCRIPTION
## Summary
- update main loop to handle list results returned by agents
- expose `ejecutar_ciclo` helper and use it inside main
- require `httpx` for tests
- test new agent addition and removal behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68431198e6b88322a27ec77b8ca67e32