### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,5 +154,5 @@ frameworks can consume.
 ## Notes
 
 Most modules under `visualizacion/` remain lightweight, but now include a
-utility to generarate heatmaps from Metatron logs. The main focus continues to
+utility to generate heatmaps from Metatron logs. The main focus continues to
 be the command line simulation found in `main.py` and the SPS API.


### PR DESCRIPTION
## Summary
- fix spelling mistake in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx' / 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_b_684317e82a18832287a26050680203e7