### PR TITLE
Add httpx dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - uvicorn
   - plotly
   - dash
+  - httpx


### PR DESCRIPTION
## Summary
- include `httpx` in the conda environment requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68433f40e0a88322b777c1caf0dca9a7