### PR TITLE
Fix unused import in mensajero

### DIFF
--- a/ecosistema_ia/agentes/tipos/sublimes/mensajero.py
+++ b/ecosistema_ia/agentes/tipos/sublimes/mensajero.py
@@ -3,7 +3,7 @@
 import csv
 import os
 from datetime import datetime
-from collections import defaultdict, Counter
+from collections import Counter
 from ecosistema_ia.agentes.tipos.sublimes.sublime_base import SublimeBase
 
 class Mensajero(SublimeBase):


### PR DESCRIPTION
## Summary
- clean up unused `defaultdict` import in `mensajero.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68433ff06a5883229a9c5d50860e3002