### PR TITLE
Remove unused initial constants

### DIFF
--- a/ecosistema_ia/config.py
+++ b/ecosistema_ia/config.py
@@ -4,15 +4,9 @@
 
 from pathlib import Path
 
-# Número de ciclos evolutivos iniciales
-CICLOS_INICIALES = 10
-
 # Parámetros generales del ecosistema
 TAMANO_TERRITORIO_X = 10
 TAMANO_TERRITORIO_Y = 10
-
-# Parámetros para agentes
-NUM_AGENTES_INICIALES = 5
 
 # Directorios base
 BASE_DIR = Path(__file__).resolve().parent

--- a/tests/test_config_no_initials.py
+++ b/tests/test_config_no_initials.py
@@ -1,0 +1,8 @@
+import pytest
+
+import ecosistema_ia.config as cfg
+
+
+def test_config_no_unused_constants():
+    assert not hasattr(cfg, "CICLOS_INICIALES")
+    assert not hasattr(cfg, "NUM_AGENTES_INICIALES")


### PR DESCRIPTION
## Summary
- delete `CICLOS_INICIALES` and `NUM_AGENTES_INICIALES` from the config
- ensure the constants are absent via a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684378fe527083228c0d28ac64c89c92