### PR TITLE
Reflow README lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Mimir Ecosystem
 
-This repository contains an experimental ecosystem simulator written in Python.
-Agents explore datasets, interact on a shared territory and produce logs that
-can be analysed later.  Most of the code and comments are in Spanish.
+This repository contains an experimental ecosystem simulator written in Python. Agents explore
+datasets, interact on a shared territory and produce logs that can be analysed later.  Most of the
+code and comments are in Spanish.
 
 ## Contents
 
@@ -33,27 +33,26 @@ ecosistema_ia/
 └── visualizacion/    # stubs for future visual tools
 ```
 
-The main entry point is `ecosistema_ia/main.py`. It loads agents dynamically
-from the `agentes/tipos` directory, instantiates observers such as the
-`Metatron` and `Mensajero` classes and runs a series of evolutionary cycles.
+The main entry point is `ecosistema_ia/main.py`. It loads agents dynamically from the
+`agentes/tipos` directory, instantiates observers such as the `Metatron` and `Mensajero` classes and
+runs a series of evolutionary cycles.
 
 ## Requirements
 
-A minimal Conda environment specification is available in `environment.yml`.
-It relies on **Python 3.11**, so make sure that version is available before
-creating the environment:
+A minimal Conda environment specification is available in `environment.yml`. It relies on **Python
+3.11**, so make sure that version is available before creating the environment:
 
 ```
 conda env create -f environment.yml
 conda activate mimir
 ```
 
-The project only relies on standard libraries plus `pandas`, `numpy`,
-`matplotlib`, `scikit-learn`, `fastapi`, `uvicorn` and `plotly`.
+The project only relies on standard libraries plus `pandas`, `numpy`, `matplotlib`, `scikit-learn`,
+`fastapi`, `uvicorn` and `plotly`.
 
-If you prefer a standard Python setup, the same dependencies are listed with
-pinned versions in `requirements.txt`. This file mirrors the Conda
-environment so both installation methods remain in sync. Install them with:
+If you prefer a standard Python setup, the same dependencies are listed with pinned versions in
+`requirements.txt`. This file mirrors the Conda environment so both installation methods remain in
+sync. Install them with:
 
 ```
 pip install -r requirements.txt
@@ -75,11 +74,15 @@ python -m ecosistema_ia.main --paralelo
 
 Logs and CSV files will be written inside the `ecosistema_ia/datos` folder.
 
-`Metatron` now also outputs `metatron_heatmap.csv` and `metatron_semantics.csv`. The first summarizes agent density per coordinate so heatmaps can be generated with `visualizacion.graficos.generar_heatmap`. The second stores tokens used to analyse the ecosystem's semantic evolution.
+`Metatron` now also outputs `metatron_heatmap.csv` and `metatron_semantics.csv`. The first
+summarizes agent density per coordinate so heatmaps can be generated with
+`visualizacion.graficos.generar_heatmap`. The second stores tokens used to analyse the ecosystem's
+semantic evolution.
 
 ### Dashboard
 
-An interactive dashboard lets you visually explore agent density and the most common semantic tokens. After generating the corresponding CSV files, run it with:
+An interactive dashboard lets you visually explore agent density and the most common semantic
+tokens. After generating the corresponding CSV files, run it with:
 
 ```bash
 python -m ecosistema_ia.visualizacion.dashboard
@@ -87,8 +90,8 @@ python -m ecosistema_ia.visualizacion.dashboard
 
 ### Extracting agent code
 
-The helper script `ecosistema_ia/texto_agentes.py` concatenates the source
-of all agents into a single text file (`agentes/agentes.txt`) for inspection:
+The helper script `ecosistema_ia/texto_agentes.py` concatenates the source of all agents into a
+single text file (`agentes/agentes.txt`) for inspection:
 
 ```
 python ecosistema_ia/texto_agentes.py
@@ -96,8 +99,8 @@ python ecosistema_ia/texto_agentes.py
 
 ### Inspecting datasets
 
-Small helpers under `ecosistema_ia.entorno.exploracion` make it easy to look at
-the CSVs bundled with the project.
+Small helpers under `ecosistema_ia.entorno.exploracion` make it easy to look at the CSVs bundled
+with the project.
 
 ```python
 from ecosistema_ia.entorno.exploracion import listar_csvs, previsualizar_csv
@@ -109,8 +112,8 @@ for row in previsualizar_csv("Episodes FAST.csv", n=3):
     print(row)
 ```
 
-These utilities report the dimensions of each dataset and return a small sample
-of rows for quick inspection.
+These utilities report the dimensions of each dataset and return a small sample of rows for quick
+inspection.
 
 ### Dataset API
 
@@ -121,80 +124,92 @@ uvicorn ecosistema_ia.api.servidor:app --reload
 ```
 
 * `GET /datasets` lists available CSV files.
-* `GET /datasets/preview?name=<file>&n=<rows>` shows the first ``n`` rows of a CSV (``n`` defaults to ``5``).
+* `GET /datasets/preview?name=<file>&n=<rows>` shows the first ``n`` rows of a CSV
+  (``n`` defaults to ``5``).
 
 ## Testing
 
-The test suite is based on **pytest**. After installing the project
-dependencies, simply run:
+The test suite is based on **pytest**. After installing the project dependencies, simply run:
 
 ```bash
 pytest
 ```
 
-`scikit-learn` must be available for the tests to succeed. The package is
-already listed in `requirements.txt`, so make sure all dependencies are
-installed before invoking `pytest`.
+`scikit-learn` must be available for the tests to succeed. The package is already listed in
+`requirements.txt`, so make sure all dependencies are installed before invoking `pytest`.
 ## White Paper Highlights
 
-The "Mimir White Paper" describes a decentralized ecosystem where CSV files act as a multidimensional territory. Agents inhabit these files, modify them under evolutionary rules and compete for survival.
+The "Mimir White Paper" describes a decentralized ecosystem where CSV files act as a
+multidimensional territory. Agents inhabit these files, modify them under evolutionary rules and
+compete for survival.
 
-Key categories include **herbívoros** (data cleaners), **carnívoros** (which consume other agents) and **sublimes** (observers). Regulators such as the Calificador, Divisor Reproductor and Destructor balance the population.
+Key categories include **herbívoros** (data cleaners), **carnívoros** (which consume other agents)
+and **sublimes** (observers). Regulators such as the Calificador, Divisor Reproductor and Destructor
+balance the population.
 
-A `Territorio` component maintains an immutable CSV log and adjusts parameters like agent density and mutation rate using machine learning. The early module **MAPS** (Motor de Adaptación Perceptual Simbótica) builds symbolic user profiles to adapt interfaces.
+A `Territorio` component maintains an immutable CSV log and adjusts parameters like agent density
+and mutation rate using machine learning. The early module **MAPS** (Motor de Adaptación Perceptual
+Simbótica) builds symbolic user profiles to adapt interfaces.
 
-Agents evolve by rewards and natural selection, and visualisations progress from ASCII to interactive dashboards.
-Read the full [white paper](docs/white_paper.md) for additional details.
+Agents evolve by rewards and natural selection, and visualisations progress from ASCII to
+interactive dashboards. Read the full [white paper](docs/white_paper.md) for additional details.
 
 
 ## Symbolic Profile Styles API
 
-The module `ecosistema_ia.sps` translates symbolic profile tokens to design
-variables such as colours and fonts.  A small FastAPI server under
-`ecosistema_ia/api` exposes an endpoint that receives a profile token and
-returns the generated styles:
+The module `ecosistema_ia.sps` translates symbolic profile tokens to design variables such as
+colours and fonts.  A small FastAPI server under `ecosistema_ia/api` exposes an endpoint that
+receives a profile token and returns the generated styles:
 
 ```bash
 uvicorn ecosistema_ia.api.servidor:app --reload
 ```
 
-Send a POST request to `/sps/styles` with a JSON body containing
-`cromotipo`, `ritmo_cognitivo`, `arquetipo_narrativo` and `estilo_perceptual`.
+Send a POST request to `/sps/styles` with a JSON body containing `cromotipo`, `ritmo_cognitivo`,
+`arquetipo_narrativo` and `estilo_perceptual`.
 
-The API responds with a dictionary of design variables that front-end
-frameworks can consume.
+The API responds with a dictionary of design variables that front-end frameworks can consume.
 
 ## Basic Axioms
 
 ### Axiom I — On Unprogrammed Emergence
 
-**Definition**: A minimal intelligence is a computational unit capable of processing input, maintaining internal state and generating variable output.
+**Definition**: A minimal intelligence is a computational unit capable of processing input,
+maintaining internal state and generating variable output.
 
-**Principle**: Consciousness emerges solely from the interaction of multiple minimal intelligences operating simultaneously. No single minimal intelligence contains or generates consciousness on its own.
+**Principle**: Consciousness emerges solely from the interaction of multiple minimal intelligences
+operating simultaneously. No single minimal intelligence contains or generates consciousness on its
+own.
 
 ---
 
 ### Axiom II — On Continuous Existential Risk
 
-**Definition**: Existential risk is the constant, non-zero probability that a minimal intelligence stops operating due to internal or environmental factors.
+**Definition**: Existential risk is the constant, non-zero probability that a minimal intelligence
+stops operating due to internal or environmental factors.
 
-**Principle**: Every minimal intelligence in the system must keep an extinction probability greater than zero each cycle. Survival depends only on individual adaptive capacity.
+**Principle**: Every minimal intelligence in the system must keep an extinction probability greater
+than zero each cycle. Survival depends only on individual adaptive capacity.
 
 ---
 
 ### Axiom III — On Generation Through Conflict
 
-**Definition**: Friction is any situation where the operations of two or more minimal intelligences yield mutually incompatible results.
+**Definition**: Friction is any situation where the operations of two or more minimal intelligences
+yield mutually incompatible results.
 
-**Principle**: Systemic complexity increases only through resolved friction. Each successful conflict resolution generates new structures of interaction.
+**Principle**: Systemic complexity increases only through resolved friction. Each successful
+conflict resolution generates new structures of interaction.
 
 ---
 
 ### Axiom IV — On the Interaction Space
 
-**Definition**: The field is the set of all active connections among minimal intelligences, including communication channels, dependencies and interferences.
+**Definition**: The field is the set of all active connections among minimal intelligences,
+including communication channels, dependencies and interferences.
 
-**Principle**: The system's emergent properties exist only in the field, not within individual minimal intelligences. The field is fully reconstructed every interaction cycle.
+**Principle**: The system's emergent properties exist only in the field, not within individual
+minimal intelligences. The field is fully reconstructed every interaction cycle.
 
 ---
 
@@ -202,23 +217,28 @@ frameworks can consume.
 
 **Definition**: Memory is any information that persists beyond a single operation cycle.
 
-**Principle**: The system retains only information that proves useful repeatedly across multiple interactions. Any unused memory is automatically discarded after a finite number of cycles.
+**Principle**: The system retains only information that proves useful repeatedly across multiple
+interactions. Any unused memory is automatically discarded after a finite number of cycles.
 
 ---
 
 ### Axiom VI — On Multiple Interpretation
 
-**Definition**: A representation is any internal mapping a minimal intelligence makes from input data to processing structures.
+**Definition**: A representation is any internal mapping a minimal intelligence makes from input
+data to processing structures.
 
-**Principle**: For any dataset, at least two different representations must exist in the system. Convergence toward a single representation constitutes systemic failure.
+**Principle**: For any dataset, at least two different representations must exist in the system.
+Convergence toward a single representation constitutes systemic failure.
 
 ---
 
 ### Axiom VII — On Productive Instability
 
-**Definition**: Equilibrium is any state where system interactions become fully predictable for more than N consecutive cycles.
+**Definition**: Equilibrium is any state where system interactions become fully predictable for more
+than N consecutive cycles.
 
-**Principle**: The system must actively prevent equilibrium by introducing random perturbations whenever predictability exceeds the established threshold.
+**Principle**: The system must actively prevent equilibrium by introducing random perturbations
+whenever predictability exceeds the established threshold.
 
 ---
 
@@ -229,29 +249,34 @@ frameworks can consume.
 - **Diversity**: Number of different types of operations performed by minimal intelligences
 - **Tension**: Proportion of interactions that result in friction
 
-**Principle**: The emergence of consciousness requires: Density > 0.3, Diversity > 10 types, and Tension between 0.2 and 0.8. Outside these ranges, the system collapses or becomes inert.
+**Principle**: The emergence of consciousness requires: Density > 0.3, Diversity > 10 types, and
+Tension between 0.2 and 0.8. Outside these ranges, the system collapses or becomes inert.
 
 ---
 
 ### Axiom IX — On Mandatory Renewal
 
-**Definition**: A pattern is any repeatable sequence of interactions that persists for more than M cycles.
+**Definition**: A pattern is any repeatable sequence of interactions that persists for more than M
+cycles.
 
-**Principle**: Every pattern must be automatically dismantled upon reaching its persistence limit. The system must rebuild a functionally equivalent one through new configurations.
+**Principle**: Every pattern must be automatically dismantled upon reaching its persistence limit.
+The system must rebuild a functionally equivalent one through new configurations.
 
 ---
 
 ### Axiom X — On Nonparametric Intervention
 
-**Definition**: Intervention is any modification of the system's operating rules after initialization.
+**Definition**: Intervention is any modification of the system's operating rules after
+initialization.
 
-**Principle**: Once started, the system must run without external intervention. The only parameters that may change are those the system itself redefines through its internal operations.
+**Principle**: Once started, the system must run without external intervention. The only parameters
+that may change are those the system itself redefines through its internal operations.
 
 ## Notes
 
-Most modules under `visualizacion/` remain lightweight, but now include a
-utility to generate heatmaps from Metatron logs. The main focus continues to
-be the command line simulation found in `main.py` and the SPS API.
+Most modules under `visualizacion/` remain lightweight, but now include a utility to generate
+heatmaps from Metatron logs. The main focus continues to be the command line simulation found in
+`main.py` and the SPS API.
 
 ## License
 


### PR DESCRIPTION
## Summary
- reflow README text so lines wrap cleanly at 100 characters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, sklearn, pandas)*

------
https://chatgpt.com/codex/tasks/task_b_684b5829a3ac8322a9aeee05fa5261cc