### PR TITLE
Implement pattern dismantling in Mensajero

### DIFF
--- a/ecosistema_ia/agentes/tipos/sublimes/mensajero.py
+++ b/ecosistema_ia/agentes/tipos/sublimes/mensajero.py
@@ -7,12 +7,14 @@ from collections import Counter
 from ecosistema_ia.agentes.tipos.sublimes.sublime_base import SublimeBase
 
 class Mensajero(SublimeBase):
-    def __init__(self, identificador="MSG-001", x=0, y=0, z=0, ruta_reporte="datos/metatron_mensajes.csv"):
+    def __init__(self, identificador="MSG-001", x=0, y=0, z=0, ruta_reporte="datos/metatron_mensajes.csv", umbral_patrones: int = 3):
         super().__init__(identificador, x, y, z, funcion="mensajero")
         self.reporte_path = ruta_reporte
         os.makedirs(os.path.dirname(self.reporte_path), exist_ok=True)
         self._inicializar_archivo()
         self.historial = []
+        self.umbral_patrones = umbral_patrones
+        self.patrones_actuales = {}
 
     def _inicializar_archivo(self):
         if not os.path.exists(self.reporte_path):
@@ -62,25 +64,40 @@ class Mensajero(SublimeBase):
                 })
 
         print(f"📨 {self.identificador} registró {len(buzon_mensajes)} mensajes en el ciclo {ciclo}.")
-        self.detectar_patrones(ciclo)
+        self.detectar_patrones(ciclo, territorio)
 
-    def detectar_patrones(self, ciclo_actual):
-        ultimos = [m for m in self.historial if ciclo_actual - m["ciclo"] <= 5]  # Últimos 5 ciclos
+    def detectar_patrones(self, ciclo_actual, territorio):
+        ultimos = [m for m in self.historial if ciclo_actual - m["ciclo"] <= 5]
 
         emisores = Counter(m["emisor"] for m in ultimos)
-        zonas = Counter((m["pos"]) for m in ultimos)
+        zonas = Counter(m["pos"] for m in ultimos)
         tipos = Counter(m["tipo"] for m in ultimos)
 
+        patrones = {}
         if emisores:
             top_emisor = emisores.most_common(1)[0]
+            patrones["emisor"] = top_emisor[0]
             print(f"👁️ {self.identificador} detecta emisor dominante: {top_emisor[0]} ({top_emisor[1]} mensajes)")
 
         if zonas:
             zona_caliente = zonas.most_common(1)[0]
+            patrones["zona"] = zona_caliente[0]
             print(f"🔥 {self.identificador} detecta zona activa: {zona_caliente[0]} ({zona_caliente[1]} mensajes)")
 
         if tipos:
             tipo_dominante = tipos.most_common(1)[0]
+            patrones["tipo"] = tipo_dominante[0]
             print(f"📡 {self.identificador} detecta mensaje dominante: tipo '{tipo_dominante[0]}' ({tipo_dominante[1]} ocurrencias)")
+
+        for k, val in patrones.items():
+            actual = self.patrones_actuales.get(k)
+            if actual and actual["valor"] == val:
+                actual["duracion"] += 1
+            else:
+                actual = {"valor": val, "duracion": 1}
+            self.patrones_actuales[k] = actual
+            if actual["duracion"] > self.umbral_patrones:
+                territorio.desmontar_patron(k, val)
+                self.patrones_actuales[k] = {"valor": None, "duracion": 0}
 
 __all__ = ["Mensajero"]

--- a/ecosistema_ia/entorno/territorio.py
+++ b/ecosistema_ia/entorno/territorio.py
@@ -184,3 +184,8 @@ class Territorio:
                 print(f"🌀 Dato dispersado en ({x},{y},{z}): {dato}")
             except Exception as e:
                 print(f"⚠️ Error al dispersar dato en ({x},{y},{z}): {e}")
+
+    def desmontar_patron(self, tipo: str, valor):
+        """Rompe un patrón persistente limpiando mensajes relacionados."""
+        print(f"♻️ Desmontando patrón {tipo} '{valor}'")
+        self.buzon_mensajes = []

--- a/tests/test_mensajero_patrones.py
+++ b/tests/test_mensajero_patrones.py
@@ -1,0 +1,31 @@
+from ecosistema_ia.agentes.tipos.sublimes.mensajero import Mensajero
+
+class DummyTerritorio:
+    def __init__(self):
+        self.buzon_mensajes = []
+        self.llamadas = []
+    def desmontar_patron(self, tipo, valor):
+        self.llamadas.append((tipo, valor))
+
+
+def _mensaje(emisor="A", pos=(0,0,0), tipo="info"):
+    x, y, z = pos
+    return {"emisor": emisor, "x": x, "y": y, "z": z, "tipo": tipo, "dato_util": "d"}
+
+
+def test_patron_se_desmonta_superado_umbral():
+    t = DummyTerritorio()
+    m = Mensajero(umbral_patrones=2)
+    for ciclo in range(3):
+        t.buzon_mensajes = [_mensaje()]
+        m.observar(t, [], ciclo)
+    assert ("emisor", "A") in t.llamadas
+
+
+def test_patron_no_desmonta_si_no_supera_umbral():
+    t = DummyTerritorio()
+    m = Mensajero(umbral_patrones=3)
+    for ciclo in range(2):
+        t.buzon_mensajes = [_mensaje()]
+        m.observar(t, [], ciclo)
+    assert t.llamadas == []


### PR DESCRIPTION
## Summary
- expand `Mensajero` to keep track of dominant patterns across cycles
- add persistence counters and threshold to `Mensajero`
- call new `Territorio.desmontar_patron` when a pattern lasts too long
- implement `Territorio.desmontar_patron`
- test pattern persistence and dismantling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c3783db9c8322a38d97b470e19da1