### PR TITLE
Add dataset summary helper and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,18 @@ Small helpers under `ecosistema_ia.entorno.exploracion` make it easy to look at 
 with the project.
 
 ```python
-from ecosistema_ia.entorno.exploracion import listar_csvs, previsualizar_csv
+from ecosistema_ia.entorno.exploracion import (
+    listar_csvs,
+    previsualizar_csv_con_resumen,
+)
 
 for info in listar_csvs():
     print(f"{info['archivo']} -> {info['filas']} filas, {info['columnas']} columnas")
 
-for row in previsualizar_csv("Episodes FAST.csv", n=3):
+rows, summary = previsualizar_csv_con_resumen("Episodes FAST.csv", n=3)
+for row in rows:
     print(row)
+print("Resumen:", summary)
 ```
 
 These utilities report the dimensions of each dataset and return a small sample of rows for quick
@@ -137,7 +142,7 @@ uvicorn ecosistema_ia.api.servidor:app --reload --port 8000
 
 * `GET /datasets` lists available CSV files.
 * `GET /datasets/preview?name=<file>&n=<rows>` shows the first ``n`` rows of a CSV
-  (``n`` defaults to ``5``).
+  and returns simple statistics for numeric columns (``n`` defaults to ``5``).
 
 #### Example usage
 
@@ -163,7 +168,11 @@ Expected responses are JSON documents like:
     ["Client", "Country", "Date Month", "Uniques", "Time Watched Minutes", "Avg Min per Unique", "Sessions"],
     ["Canela", "Albania", "Apr-2024", "18", "19.100000000000005", "1.0611111111111111", "35"],
     ["Canela", "Algeria", "Apr-2024", "405", "267.0833333333338", "0.6594650205761317", "588"]
-  ]
+  ],
+  "summary": {
+    "Uniques": 102.3,
+    "Sessions": 345.8
+  }
 }
 ```
 

--- a/ecosistema_ia/api/endpoints.py
+++ b/ecosistema_ia/api/endpoints.py
@@ -3,7 +3,11 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 from ecosistema_ia.sps import SymbolicProfile, generate_styles
-from ecosistema_ia.entorno.exploracion import listar_csvs, previsualizar_csv
+from ecosistema_ia.entorno.exploracion import (
+    listar_csvs,
+    previsualizar_csv,
+    previsualizar_csv_con_resumen,
+)
 
 router = APIRouter()
 
@@ -31,6 +35,6 @@ def get_datasets():
 
 @router.get("/datasets/preview")
 def preview_dataset(name: str, n: int = 5):
-    """Return the first ``n`` rows of the selected CSV file."""
-    rows = previsualizar_csv(name, n=n)
-    return {"preview": rows}
+    """Return the first ``n`` rows and basic stats of the selected CSV file."""
+    rows, summary = previsualizar_csv_con_resumen(name, n=n)
+    return {"preview": rows, "summary": summary}

--- a/ecosistema_ia/entorno/exploracion.py
+++ b/ecosistema_ia/entorno/exploracion.py
@@ -1,8 +1,9 @@
 """Utilidades simples para inspeccionar datasets CSV."""
 
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Tuple
 import csv
+import pandas as pd
 
 from ..config import DATASETS_DIR
 
@@ -58,4 +59,21 @@ def previsualizar_csv(nombre: str, n: int = 5, ruta: Path = DATASETS_DIR) -> Lis
     return filas
 
 
-__all__ = ["listar_csvs", "previsualizar_csv"]
+def previsualizar_csv_con_resumen(
+    nombre: str, n: int = 5, ruta: Path = DATASETS_DIR
+) -> Tuple[List[List[str]], Dict[str, float]]:
+    """Devuelve ``n`` filas del CSV junto con medias de columnas numéricas."""
+    filas = previsualizar_csv(nombre, n=n, ruta=ruta)
+    csv_path = Path(ruta) / nombre
+    resumen: Dict[str, float] = {}
+    if csv_path.exists():
+        try:
+            df = pd.read_csv(csv_path)
+            num_df = df.select_dtypes(include="number")
+            resumen = {col: num_df[col].mean() for col in num_df.columns}
+        except Exception as e:  # pragma: no cover - solo para depuración manual
+            print(f"⚠️ Error al calcular estadísticas de {csv_path}: {e}")
+    return filas, resumen
+
+
+__all__ = ["listar_csvs", "previsualizar_csv", "previsualizar_csv_con_resumen"]

--- a/tests/test_api_datasets.py
+++ b/tests/test_api_datasets.py
@@ -26,3 +26,5 @@ def test_preview_has_expected_rows():
     preview = data["preview"]
     assert isinstance(preview, list)
     assert len(preview) == n + 1
+    assert "summary" in data
+    assert isinstance(data["summary"], dict)


### PR DESCRIPTION
## Summary
- extend dataset exploration utilities with a new `previsualizar_csv_con_resumen`
- expose summary stats from `/datasets/preview`
- update README to document new helper and API behaviour
- adjust tests for new JSON structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c43b8655c832296a8427a7cca6a3c