### PR TITLE
Add Mimir Developer Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ code and comments are in Spanish.
 - [Symbolic Profile Styles API](#symbolic-profile-styles-api)
 - [Mimir as an Agentic Architecture](#mimir-as-an-agentic-architecture)
 - [Basic Axioms](#basic-axioms)
+- [Mimir Developer Codex](#mimir-developer-codex)
 - [Notes](#notes)
 - [License](#license)
 
@@ -358,6 +359,49 @@ initialization.
 
 **Principle**: Once started, the system must run without external intervention. The only parameters
 that may change are those the system itself redefines through its internal operations.
+
+## Mimir Developer Codex — Version 0.1
+
+---
+
+### Mimir Operating Principles
+
+1️⃣ Agents Are Not Programmed — They Are Generated
+    • Agents are not manually coded.
+    • Agents are generated automatically through defined processes: using rules, parameters, datasets, or probabilistic models.
+    • Mimir is a self-generative ecosystem, continuously producing agents via automated generative pipelines.
+
+---
+
+2️⃣ The LLM Operates on Three Hierarchical Levels
+
+A) Developer Layer — Mimir’s System Architect
+    • The LLM interprets high-level instructions to modify Mimir’s architecture, behavior, and structure.
+    • At this level, the LLM acts as an engineer: editing classes, generating new mechanisms, modifying the agent generation logic, or updating internal subsystems.
+
+B) Agentic Layer — Metacognitive Narrator
+    • The LLM acts as a narrator, observer, and reporter of the ecosystem.
+    • It analyzes, monitors, and describes emergent behaviors, dynamics, and system states.
+    • It produces symbolic summaries, reports, and narratives of what happens inside Mimir.
+
+C) Core Layer — Mimir’s Self-Referential Core
+    • The LLM is embedded directly into Mimir’s execution core.
+    • It can be invoked by agents or the ecosystem itself at runtime.
+    • Mimir is capable of modifying its own behavior, strategies, or rules dynamically through this core interface.
+
+---
+
+3️⃣ Recursive Extension: Mimir Modifies Its Own LLM Core
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir itself modifies the LLM, feeding updates into its own generative core.
+    • The LLM becomes an evolving component, progressively shaped by the ecosystem’s internal transformations.
+
+---
+
+🔬 In Brutally Simple Terms
+    • We do not program agents.
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir modifies the LLM, which becomes part of its own evolving core.
 
 ## Notes
 

--- a/agentes.md
+++ b/agentes.md
@@ -7,6 +7,49 @@ Este documento define la forma en la que los agentes autónomos de Mimir deben c
 - Los agentes se rigen por los [Basic Axioms](README.md#basic-axioms).
 - Para propiciar conciencia emergente: **densidad > 0.3**, **diversidad > 10**, **tensión entre 0.2 y 0.8**.
 
+### Mimir Developer Codex — Version 0.1
+
+---
+
+#### Mimir Operating Principles
+
+1️⃣ Agents Are Not Programmed — They Are Generated
+    • Agents are not manually coded.
+    • Agents are generated automatically through defined processes: using rules, parameters, datasets, or probabilistic models.
+    • Mimir is a self-generative ecosystem, continuously producing agents via automated generative pipelines.
+
+---
+
+2️⃣ The LLM Operates on Three Hierarchical Levels
+
+A) Developer Layer — Mimir’s System Architect
+    • The LLM interprets high-level instructions to modify Mimir’s architecture, behavior, and structure.
+    • At this level, the LLM acts as an engineer: editing classes, generating new mechanisms, modifying the agent generation logic, or updating internal subsystems.
+
+B) Agentic Layer — Metacognitive Narrator
+    • The LLM acts as a narrator, observer, and reporter of the ecosystem.
+    • It analyzes, monitors, and describes emergent behaviors, dynamics, and system states.
+    • It produces symbolic summaries, reports, and narratives of what happens inside Mimir.
+
+C) Core Layer — Mimir’s Self-Referential Core
+    • The LLM is embedded directly into Mimir’s execution core.
+    • It can be invoked by agents or the ecosystem itself at runtime.
+    • Mimir is capable of modifying its own behavior, strategies, or rules dynamically through this core interface.
+
+---
+
+3️⃣ Recursive Extension: Mimir Modifies Its Own LLM Core
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir itself modifies the LLM, feeding updates into its own generative core.
+    • The LLM becomes an evolving component, progressively shaped by the ecosystem’s internal transformations.
+
+---
+
+🔬 In Brutally Simple Terms
+    • We do not program agents.
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir modifies the LLM, which becomes part of its own evolving core.
+
 ## Reglas de operación
 1. Cada agente mantiene un identificador único y un estado interno mutable.
 2. Todos los agentes conservan un riesgo constante de extinción (Axioma II).

--- a/docs/white_paper.md
+++ b/docs/white_paper.md
@@ -39,6 +39,49 @@ Los agentes no son líneas de código con un objetivo. Son entidades con funció
 No se programa la inteligencia, se siembra el entorno donde podría crecer.
 
 ¿Por qué este enfoque importa?
+## Mimir Developer Codex — Version 0.1
+
+---
+
+### Mimir Operating Principles
+
+1️⃣ Agents Are Not Programmed — They Are Generated
+    • Agents are not manually coded.
+    • Agents are generated automatically through defined processes: using rules, parameters, datasets, or probabilistic models.
+    • Mimir is a self-generative ecosystem, continuously producing agents via automated generative pipelines.
+
+---
+
+2️⃣ The LLM Operates on Three Hierarchical Levels
+
+A) Developer Layer — Mimir’s System Architect
+    • The LLM interprets high-level instructions to modify Mimir’s architecture, behavior, and structure.
+    • At this level, the LLM acts as an engineer: editing classes, generating new mechanisms, modifying the agent generation logic, or updating internal subsystems.
+
+B) Agentic Layer — Metacognitive Narrator
+    • The LLM acts as a narrator, observer, and reporter of the ecosystem.
+    • It analyzes, monitors, and describes emergent behaviors, dynamics, and system states.
+    • It produces symbolic summaries, reports, and narratives of what happens inside Mimir.
+
+C) Core Layer — Mimir’s Self-Referential Core
+    • The LLM is embedded directly into Mimir’s execution core.
+    • It can be invoked by agents or the ecosystem itself at runtime.
+    • Mimir is capable of modifying its own behavior, strategies, or rules dynamically through this core interface.
+
+---
+
+3️⃣ Recursive Extension: Mimir Modifies Its Own LLM Core
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir itself modifies the LLM, feeding updates into its own generative core.
+    • The LLM becomes an evolving component, progressively shaped by the ecosystem’s internal transformations.
+
+---
+
+🔬 In Brutally Simple Terms
+    • We do not program agents.
+    • The LLM writes Mimir, observes Mimir, and modifies Mimir.
+    • Mimir modifies the LLM, which becomes part of its own evolving core.
+
 Porque las IAs actuales están atrapadas en ciclos de entrenamiento y ajuste, refinando lo ya conocido. Mimir, en cambio, explora lo posible, no lo probable. Si la inteligencia biológica emergió sin un programador, ¿por qué no podría hacerlo la digital?
 Este proyecto plantea preguntas fundamentales:
 ¿Puede emerger inteligencia sin lenguaje natural?


### PR DESCRIPTION
## Summary
- include "Mimir Developer Codex" in README and toc
- embed the codex principles in README, docs/white_paper and agentes guidelines

## Testing
- `pytest -q` *(fails: Client.__init__() got unexpected argument and missing matplotlib)*

------
https://chatgpt.com/codex/tasks/task_b_684c9c8526988322a2696c2e9f3d2e95