### PR TITLE
Implement profile engine and code generation

### DIFF
--- a/ecosistema_ia/api/endpoints.py
+++ b/ecosistema_ia/api/endpoints.py
@@ -2,7 +2,11 @@
 
 from fastapi import APIRouter
 from pydantic import BaseModel
-from ecosistema_ia.sps import SymbolicProfile, generate_styles
+from ecosistema_ia.sps import (
+    SymbolicProfile,
+    generate_styles,
+    ProfileEngine,
+)
 from ecosistema_ia.entorno.exploracion import (
     listar_csvs,
     previsualizar_csv,
@@ -10,6 +14,7 @@ from ecosistema_ia.entorno.exploracion import (
 )
 
 router = APIRouter()
+engine = ProfileEngine()
 
 
 class ProfileToken(BaseModel):
@@ -25,6 +30,13 @@ def get_styles(token: ProfileToken):
     profile = SymbolicProfile(**token.dict())
     styles = generate_styles(profile.to_token())
     return {"styles": styles}
+
+
+@router.post("/sps/code")
+def get_code(token: ProfileToken):
+    """Return CSS and React snippets for a symbolic profile."""
+    result = engine.generate_code(token.dict())
+    return result
 
 
 @router.get("/datasets")

--- a/ecosistema_ia/sps/__init__.py
+++ b/ecosistema_ia/sps/__init__.py
@@ -2,5 +2,6 @@
 
 from .models import SymbolicProfile
 from .mappings import generate_styles
+from .engine import ProfileEngine, TranslationLayer
 
-__all__ = ["SymbolicProfile", "generate_styles"]
+__all__ = ["SymbolicProfile", "generate_styles", "ProfileEngine", "TranslationLayer"]

--- a/ecosistema_ia/sps/engine.py
+++ b/ecosistema_ia/sps/engine.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Engine for translating symbolic profiles into design code snippets."""
+
+from typing import Dict, Union
+
+from .models import SymbolicProfile
+from .mappings import generate_styles
+
+
+class TranslationLayer:
+    """Convert design variables into CSS and React code snippets."""
+
+    def to_css(self, styles: Dict[str, str]) -> str:
+        """Return a minimal CSS snippet applying the styles."""
+        color = styles.get("color_primario", "#FFF")
+        font = styles.get("fuente_base", "sans-serif")
+        return (
+            ".profile {\n"
+            f"  color: {color};\n"
+            f"  font-family: {font};\n"
+            "}"
+        )
+
+    def to_react(self, styles: Dict[str, str]) -> str:
+        """Return a React component snippet using the styles."""
+        color = styles.get("color_primario", "#FFF")
+        font = styles.get("fuente_base", "sans-serif")
+        icon = styles.get("icono", "star")
+        anim = styles.get("animacion", "fade")
+        return (
+            "const Profile = () => (\n"
+            "  <div className=\"profile\">\n"
+            f"    <i className=\"icon-{icon} {anim}\" "
+            f"style={{color: '{color}', fontFamily: '{font}'}} />\n"
+            "  </div>\n"
+            ");"
+        )
+
+
+class ProfileEngine:
+    """High level interface for generating design code from a profile token."""
+
+    def __init__(self, translator: TranslationLayer | None = None) -> None:
+        self.translator = translator or TranslationLayer()
+
+    def translate(self, profile: Union[SymbolicProfile, Dict[str, str]]) -> Dict[str, str]:
+        """Translate a profile token into design variables."""
+        if isinstance(profile, SymbolicProfile):
+            token = profile.to_token()
+        else:
+            token = profile
+        return generate_styles(token)
+
+    def generate_code(self, profile: Union[SymbolicProfile, Dict[str, str]]) -> Dict[str, str]:
+        """Generate CSS and React snippets for the given profile."""
+        styles = self.translate(profile)
+        css = self.translator.to_css(styles)
+        react = self.translator.to_react(styles)
+        return {"styles": styles, "css": css, "react": react}
+
+__all__ = ["TranslationLayer", "ProfileEngine"]
+

--- a/tests/test_profile_code_generation.py
+++ b/tests/test_profile_code_generation.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from ecosistema_ia.api.servidor import app
+from ecosistema_ia.sps.mappings import (
+    CROMOTIPO_COLOR,
+    RITMO_TIPOGRAFIA,
+    ARQUETIPO_ICONO,
+    ESTILO_ANIMACION,
+)
+
+client = TestClient(app)
+
+
+def test_profile_to_code_roundtrip():
+    token = {
+        "cromotipo": "sol",
+        "ritmo_cognitivo": "lento",
+        "arquetipo_narrativo": "explorador",
+        "estilo_perceptual": "visual",
+    }
+    response = client.post("/sps/code", json=token)
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"styles", "css", "react"}
+
+    styles = data["styles"]
+    assert styles["color_primario"] == CROMOTIPO_COLOR[token["cromotipo"]]
+    assert styles["fuente_base"] == RITMO_TIPOGRAFIA[token["ritmo_cognitivo"]]
+    assert styles["icono"] == ARQUETIPO_ICONO[token["arquetipo_narrativo"]]
+    assert styles["animacion"] == ESTILO_ANIMACION[token["estilo_perceptual"]]
+
+    assert styles["color_primario"] in data["css"]
+    assert styles["fuente_base"] in data["css"]
+    assert styles["icono"] in data["react"]
+    assert styles["animacion"] in data["react"]


### PR DESCRIPTION
## Summary
- implement `ProfileEngine` and `TranslationLayer` for SPS
- expose `/sps/code` endpoint returning styles, CSS and React snippets
- add integration test for profile -> code generation round trip

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863fcefa96083229fa8448715789c57