### PR TITLE
Add documentation outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,9 @@ Requires `scikit-learn` and all dependencies listed in `requirements.txt`.
 
 - 📖 [Complete White Paper](docs/white_paper.md) - Full theoretical framework
 - 🔧 [Developer Codex](docs/developer_codex.md) - Implementation principles  
-- 🎨 [SPS Profile System](docs/sps_profiles.md) - Adaptive interface mechanics
+- 🎨 [SPS Profile System](docs/sps_profile_system.md) - Adaptive interface mechanics
 - 📊 [Consciousness Metrics](docs/consciousness_metrics.md) - Emergence measurement
-- 🧪 [Agent Development Guide](docs/agent_development.md) - Create new agent types
+- 🧪 [Agent Development Guide](docs/agent_development_guide.md) - Create new agent types
 
 ---
 

--- a/docs/agent_development_guide.md
+++ b/docs/agent_development_guide.md
@@ -1,0 +1,17 @@
+# Agent Development Guide
+
+This guide outlines how to create new agent types for Mimir.
+
+1. **Create a Class**
+   - Inherit from `AgenteBase` or an existing subtype.
+   - Implement the `procesar_ciclo` method to define agent behavior.
+
+2. **Place the File**
+   - Add the new module inside `ecosistema_ia/agentes/tipos/` or a plugin directory.
+   - Modules placed under `ecosistema_ia/plugins/` are automatically discovered.
+
+3. **Test the Agent**
+   - Write unit tests in `tests/` to validate core logic.
+   - Run `pytest` to ensure the ecosystem loads your new type correctly.
+
+By following these steps you can expand the ecosystem with minimal manual configuration.

--- a/docs/consciousness_metrics.md
+++ b/docs/consciousness_metrics.md
@@ -1,0 +1,25 @@
+# Consciousness Metrics
+
+Mimir tracks several metrics to estimate emergent consciousness.
+
+## Density
+
+The ratio of active connections to the theoretical maximum.
+Calculated by measuring nearby agent interactions in the same layer.
+
+## Diversity
+
+The number of distinct agent operation types present in the ecosystem.
+
+## Tension
+
+The proportion of conflict messages relative to total interactions.
+Tension should remain between **0.2** and **0.8**.
+
+## Integrated Information (Φ)
+
+A lightweight Φ estimate is computed from spatially close agent pairs.
+It represents connectedness within an agent cluster.
+
+All four metrics are recorded each cycle and stored in the territory logs.
+Consciousness tends to emerge when density exceeds **0.3**, diversity is greater than **10**, and tension stays within the specified range.

--- a/docs/developer_codex.md
+++ b/docs/developer_codex.md
@@ -1,0 +1,16 @@
+# Developer Codex
+
+This codex summarizes key principles from `agentes.md` lines 10-36.
+
+## Operating Principles
+
+- **Agents Are Generated, Not Programmed**
+  - Agents arise automatically from rules, parameters and datasets.
+  - Mimir continuously produces new agents via generative pipelines.
+
+- **The LLM Works on Three Levels**
+  - **Developer Layer** – interprets high level instructions to modify the ecosystem.
+  - **Agentic Layer** – observes and narrates emergent behavior.
+  - **Core Layer** – embedded within Mimir so agents can invoke it at runtime.
+
+These guidelines ensure that Mimir remains a self-generating, self-observing architecture where agents evolve through automated processes.

--- a/docs/sps_profile_system.md
+++ b/docs/sps_profile_system.md
@@ -1,0 +1,23 @@
+# SPS Profile System
+
+The Symbolic Profile System (SPS) defines a set of symbolic fields that drive interface adaptation.
+
+## Profile Fields
+
+- `cromotipo` – color archetype of the user or agent.
+- `ritmo_cognitivo` – preferred cognitive tempo (slow, medium, fast).
+- `arquetipo_narrativo` – narrative archetype used for icons and motifs.
+- `estilo_perceptual` – perceptual style influencing animations.
+
+## Example
+
+```json
+{
+  "cromotipo": "sol",
+  "ritmo_cognitivo": "medio",
+  "arquetipo_narrativo": "explorador",
+  "estilo_perceptual": "visual"
+}
+```
+
+The engine maps these symbolic values to design variables (colors, fonts, icons, animations) which are then translated into CSS or React code snippets.


### PR DESCRIPTION
## Summary
- document core operating principles in Developer Codex
- create overview of the Symbolic Profile System
- explain consciousness metrics and Φ calculations
- outline how to add new agent types
- update README links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_6863ff0cfe10832280d4c12d6b8225fb