### PR TITLE
Add metrics API endpoint and tests

### DIFF
--- a/ecosistema_ia/api/endpoints.py
+++ b/ecosistema_ia/api/endpoints.py
@@ -12,9 +12,11 @@ from ecosistema_ia.entorno.exploracion import (
     previsualizar_csv,
     previsualizar_csv_con_resumen,
 )
+from ecosistema_ia.entorno.territorio import Territorio
 
 router = APIRouter()
 engine = ProfileEngine()
+territorio = Territorio()
 
 
 class ProfileToken(BaseModel):
@@ -50,3 +52,9 @@ def preview_dataset(name: str, n: int = 5):
     """Return the first ``n`` rows and basic stats of the selected CSV file."""
     rows, summary = previsualizar_csv_con_resumen(name, n=n)
     return {"preview": rows, "summary": summary}
+
+
+@router.get("/metrics/latest")
+def latest_metrics():
+    """Return the most recent Territorio metrics."""
+    return territorio.get_estado_json()

--- a/tests/test_api_metrics.py
+++ b/tests/test_api_metrics.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from ecosistema_ia.api.servidor import app
+from ecosistema_ia.api.endpoints import territorio
+from ecosistema_ia.main import ejecutar_ciclo
+from ecosistema_ia.agentes.tipos.herbivoros.herbivoro import Herbivoro
+
+
+def _herbivoro(id_):
+    h = Herbivoro(id_, 0, 0, 0)
+    h.memoria.append({"dato": "x"})
+    return h
+
+
+def test_metrics_latest_contains_fields():
+    territorio.historial_estados = []
+    agentes = [_herbivoro("H1"), _herbivoro("H2")]
+    agentes = ejecutar_ciclo(agentes, territorio)
+    territorio.regular(agentes, ciclo=1)
+
+    client = TestClient(app)
+    response = client.get("/metrics/latest")
+    assert response.status_code == 200
+    data = response.json()
+    assert "densidad" in data
+    assert "diversidad" in data
+    assert "tension" in data


### PR DESCRIPTION
## Summary
- add `Territorio` to API router and new `/metrics/latest` endpoint
- implement tests ensuring metrics endpoint exposes density, diversity, and tension

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864007fb7188322942d48c1664f2b24