### PR TITLE
Add roadmap doc and README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Requires `scikit-learn` and all dependencies listed in `requirements.txt`.
 - 🎨 [SPS Profile System](docs/sps_profile_system.md) - Adaptive interface mechanics
 - 📊 [Consciousness Metrics](docs/consciousness_metrics.md) - Emergence measurement
 - 🧪 [Agent Development Guide](docs/agent_development_guide.md) - Create new agent types
+- 🗺️ [Roadmap](docs/roadmap.md) - Fase 1–3 checklist
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,22 @@
+# Project Roadmap
+
+This checklist summarizes Fase 1–3 objectives from the [white_paper](white_paper.md). Tick items as features land to keep contributions aligned.
+
+## Fase 1 – Validate Foundations
+- [ ] Functional CSV ecosystem with Territorio regulation
+- [ ] Basic agent types with genuine evolutionary mechanics
+- [ ] IIT algorithms adapted for discrete agents
+- [ ] MAPS v1.0 ready for commercialization
+
+## Fase 2 – Consciousness Framework
+- [ ] Complete Φ calculation system using IIT
+- [ ] MAPS v2.0 with adaptive AI
+- [ ] Commercializable research platform
+- [ ] Basic cognitive architectures
+
+## Fase 3 – Emergence Research
+- [ ] Investigate genuine emergent consciousness
+- [ ] Maintain diversified product portfolio
+- [ ] Document limitations if consciousness fails to emerge
+
+Update this file as features are implemented.


### PR DESCRIPTION
## Summary
- document high-level Fase 1–3 tasks in `docs/roadmap.md`
- link to the roadmap from the Advanced Documentation section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6864033b18788322a5dff6b5ff12aacc