### PR TITLE
Enable reproduction and mutation behaviours

### DIFF
--- a/ecosistema_ia/agentes/tipos/carnivoros/divisor_reproductor.py
+++ b/ecosistema_ia/agentes/tipos/carnivoros/divisor_reproductor.py
@@ -113,4 +113,20 @@ class DivisorReproductor(CarnivoroBase):
         self.ciclos_sin_reproducir = 0
         return [nuevo]
 
+    def mutar(self):
+        """Pequeña mutación al coeficiente del modelo."""
+        if hasattr(self.modelo_ml, "C"):
+            self.modelo_ml.C *= random.uniform(0.8, 1.2)
+
+    def puede_reproducirse(self):
+        return self.ciclos_sin_reproducir >= 3
+
+    def reproducirse(self, nuevo_id):
+        nuevo = DivisorReproductor(nuevo_id, self.x, self.y, self.z)
+        nuevo.memoria_acciones = list(self.memoria_acciones[-3:])
+        nuevo.mutar()
+        self.ciclos_sin_reproducir = 0
+        print(f"🧬 {self.identificador} se dividió en {nuevo.identificador}")
+        return nuevo
+
 __all__ = ["DivisorReproductor"]

--- a/ecosistema_ia/agentes/tipos/herbivoros/estadista.py
+++ b/ecosistema_ia/agentes/tipos/herbivoros/estadista.py
@@ -65,5 +65,23 @@ class Estadista(HerbivoroBase):
         self.broadcast_mensaje(territorio, stats, tipo="estadisticas")
         print(f"\U0001F4C8 {self.identificador} calculó {stats} en {self.posicion}")
 
+    def mutar(self):
+        """Aumenta ligeramente los valores estadísticos en memoria."""
+        if self.memoria:
+            ultimo = self.memoria[-1]
+            res = ultimo.get("resultado", {})
+            if isinstance(res, dict):
+                ultimo["resultado"] = {k: v * 1.1 if isinstance(v, (int, float)) else v for k, v in res.items()}
+
+    def puede_reproducirse(self):
+        return self.edad % 4 == 0
+
+    def reproducirse(self, nuevo_id):
+        nuevo = Estadista(nuevo_id, self.x, self.y, self.z)
+        nuevo.memoria = list(self.memoria[-2:])
+        nuevo.mutar()
+        print(f"🧬 {self.identificador} generó {nuevo.identificador}")
+        return nuevo
+
 
 __all__ = ["Estadista"]

--- a/ecosistema_ia/agentes/tipos/herbivoros/herbivoro.py
+++ b/ecosistema_ia/agentes/tipos/herbivoros/herbivoro.py
@@ -32,4 +32,23 @@ class Herbivoro(HerbivoroBase):
             exitoso=recompensa > 0,
         )
 
+    def mutar(self):
+        """Pequeña mutación sobre la última entrada de memoria."""
+        if self.memoria:
+            self.memoria[-1]["mutado"] = True
+
+    def puede_reproducirse(self):
+        return self.recompensa_total >= 20
+
+    def reproducirse(self, nuevo_id):
+        nuevo_x = self.x + random.choice([-1, 0, 1])
+        nuevo_y = self.y + random.choice([-1, 0, 1])
+        nuevo = Herbivoro(nuevo_id, nuevo_x, nuevo_y, self.z)
+        nuevo.memoria = list(self.memoria[-2:])
+        nuevo.recompensa_total = self.recompensa_total // 2
+        nuevo.funcion = self.funcion + "_m"
+        nuevo.mutar()
+        print(f"🧬 {self.identificador} generó {nuevo.identificador}")
+        return nuevo
+
 __all__ = ["Herbivoro"]

--- a/ecosistema_ia/agentes/tipos/omnivoros/omni_colector.py
+++ b/ecosistema_ia/agentes/tipos/omnivoros/omni_colector.py
@@ -30,5 +30,20 @@ class OmniColector(OmnivoroBase):
         vecinos = self.buscar_vecinos(otros_agentes or [])
         self.absorber_memorias(vecinos)
 
+    def mutar(self):
+        """Marca la última entrada de memoria como mutada."""
+        if self.memoria:
+            self.memoria[-1]["resultado"] = "mutado"
+
+    def puede_reproducirse(self):
+        return len(self.memoria) >= 1
+
+    def reproducirse(self, nuevo_id):
+        nuevo = OmniColector(nuevo_id, self.x, self.y, self.z)
+        nuevo.memoria = list(self.memoria[-1:])
+        nuevo.mutar()
+        print(f"🧬 {self.identificador} creó {nuevo.identificador}")
+        return nuevo
+
 
 __all__ = ["OmniColector"]

--- a/ecosistema_ia/agentes/tipos/sublimes/agente_llm.py
+++ b/ecosistema_ia/agentes/tipos/sublimes/agente_llm.py
@@ -28,5 +28,19 @@ class AgenteLLM(SublimeBase):
         self.broadcast_mensaje(territorio, respuesta, tipo="llm")
         print(f"🤖 {self.identificador} generó texto: {respuesta}")
 
+    def mutar(self):
+        """Cambia la función indicando que es un clon."""
+        self.funcion = "llm_mutado"
+
+    def puede_reproducirse(self):
+        return self.edad % 2 == 0
+
+    def reproducirse(self, nuevo_id):
+        nuevo = AgenteLLM(nuevo_id, self.x, self.y, self.z)
+        nuevo.memoria = list(self.memoria[-2:])
+        nuevo.mutar()
+        print(f"🧬 {self.identificador} clonó a {nuevo.identificador}")
+        return nuevo
+
 
 __all__ = ["AgenteLLM"]

--- a/tests/test_dynamic_loader.py
+++ b/tests/test_dynamic_loader.py
@@ -26,3 +26,25 @@ def test_base_classes_not_loaded():
     assert "SublimeBase" not in nombres
     # topologia requires extra args; ensure no instantiation error occurs
     assert "Topologia" not in nombres
+
+
+def test_agents_reproduce_and_mutate():
+    agentes = cargar_agentes_dinamicamente()
+    from ecosistema_ia.agentes.tipos.herbivoros.herbivoro import Herbivoro
+    from ecosistema_ia.agentes.tipos.omnivoros.omni_colector import OmniColector
+
+    herb = next(a for a in agentes if isinstance(a, Herbivoro))
+    herb.memoria.append({"entrada": "x", "resultado": "y"})
+    herb.recompensa_total = 25
+    assert herb.puede_reproducirse()
+    nuevo_h = herb.reproducirse("HX-001")
+    assert isinstance(nuevo_h, Herbivoro)
+    assert nuevo_h.funcion.endswith("_m")
+    assert nuevo_h.memoria[-1].get("mutado") is True
+
+    omni = next(a for a in agentes if isinstance(a, OmniColector))
+    omni.memoria.append({"entrada": "t", "resultado": "z"})
+    assert omni.puede_reproducirse()
+    nuevo_o = omni.reproducirse("OC-001")
+    assert isinstance(nuevo_o, OmniColector)
+    assert nuevo_o.memoria[-1]["resultado"] == "mutado"


### PR DESCRIPTION
## Summary
- extend `Herbivoro`, `Estadista`, `OmniColector`, `DivisorReproductor` and `AgenteLLM` with small mutation/reproduction logic
- adjust dynamic loader tests to exercise the new behaviours

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68640e9ebc488322af9a4b7005e68196