### PR TITLE
Add network efficiency φ metric

### DIFF
--- a/ecosistema_ia/metrics/iit_phi.py
+++ b/ecosistema_ia/metrics/iit_phi.py
@@ -1,31 +1,52 @@
 """Utilities for computing integrated information (Φ) in agent clusters."""
 
-from itertools import combinations
-from typing import List, Dict
+from collections import deque
+from typing import Dict, List
 
-# Placeholder algorithm for calculating integrated information.
-# Real IIT calculations would require the PyPhi library and a model of
-# agent connectivity/state transitions. For testing purposes we compute a
-# simple connectivity based on spatial distance.
+
+def _adjacency_matrix(agents: List) -> List[List[int]]:
+    """Return adjacency matrix based on proximity in the same z-layer."""
+    n = len(agents)
+    matrix = [[0] * n for _ in range(n)]
+    for i, a in enumerate(agents):
+        for j, b in enumerate(agents[i + 1 :], start=i + 1):
+            if a.z == b.z and abs(a.x - b.x) <= 1 and abs(a.y - b.y) <= 1:
+                matrix[i][j] = matrix[j][i] = 1
+    return matrix
+
+
+def _shortest_paths(adj: List[List[int]], start: int) -> List[int]:
+    """Breadth-first search distances from a node."""
+    n = len(adj)
+    dist = [-1] * n
+    dist[start] = 0
+    queue = deque([start])
+    while queue:
+        i = queue.popleft()
+        for j, linked in enumerate(adj[i]):
+            if linked and dist[j] == -1:
+                dist[j] = dist[i] + 1
+                queue.append(j)
+    return dist
+
 
 def calculate_phi_for_agent_cluster(agents: List) -> Dict[str, float]:
-    """Return a rudimentary Φ estimate for a group of agents.
+    """Estimate Φ using network efficiency over agent connections."""
 
-    The current implementation measures the ratio of close connections
-    between agents in the same z-layer. It serves as a lightweight
-    stand-in when PyPhi is unavailable.
-    """
     n = len(agents)
     if n < 2:
         return {"phi": 0.0}
 
-    connected = 0
-    for a, b in combinations(agents, 2):
-        if a.z == b.z and abs(a.x - b.x) <= 1 and abs(a.y - b.y) <= 1:
-            connected += 1
-
+    adj = _adjacency_matrix(agents)
+    efficiency = 0.0
+    for i in range(n):
+        dist = _shortest_paths(adj, i)
+        for j in range(i + 1, n):
+            d = dist[j]
+            if d > 0:
+                efficiency += 1 / d
     possible = n * (n - 1) / 2
-    phi_value = connected / possible if possible else 0.0
+    phi_value = efficiency / possible if possible else 0.0
     return {"phi": phi_value}
 
 

--- a/tests/test_iit_phi.py
+++ b/tests/test_iit_phi.py
@@ -3,11 +3,16 @@ from ecosistema_ia.entorno.territorio import Territorio
 from ecosistema_ia.agentes.tipos.testing.dummy_agents import DummyA
 
 
-def test_phi_returns_value():
+def test_phi_connected_cluster():
     agents = [DummyA("A1", 0, 0, 0), DummyA("A2", 1, 0, 0)]
     result = phi.calculate_phi_for_agent_cluster(agents)
-    assert result
-    assert result["phi"] >= 0
+    assert result["phi"] == 1.0
+
+
+def test_phi_disconnected_cluster():
+    agents = [DummyA("A1", 0, 0, 0), DummyA("A2", 5, 5, 0)]
+    result = phi.calculate_phi_for_agent_cluster(agents)
+    assert result["phi"] == 0.0
 
 
 def test_calcular_metricas_includes_phi():
@@ -15,4 +20,4 @@ def test_calcular_metricas_includes_phi():
     agents = [DummyA("A1", 0, 0, 0), DummyA("A2", 0, 1, 0)]
     metricas = territorio.calcular_metricas(agents)
     assert "phi" in metricas
-    assert metricas["phi"] >= 0
+    assert metricas["phi"] == 1.0


### PR DESCRIPTION
## Summary
- implement basic Φ computation using network efficiency
- expose phi via Territorio metricas
- test connected/disconnected clusters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68641e15e4fc832295e930327aa510f8